### PR TITLE
Update hiredis to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "delivery"
   ],
   "dependencies": {
-    "hiredis": "0.4.0",
+    "hiredis": "0.4.1",
     "redis": "0.12.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Hiredis 0.4.0 cannot compile on Node v4.

You might consider switching from hiredis and node-redis to [ioredis](https://www.npmjs.com/package/ioredis).  It's a bit more performant, doesn't require a native build, and is more actively developed.