### PR TITLE
Update ws to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "redis": "0.12.1"
   },
   "optionalDependencies": {
-    "ws": "0.7.2",
+    "ws": "0.8.0",
     "websocket-stream": "1.4.0",
     "dnode": "1.2.1"
   },


### PR DESCRIPTION
ws 0.7.2 uses an outdated version of bufferutil which cannot compile under Node v4