### PR TITLE
Update dnode to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "optionalDependencies": {
     "ws": "0.7.2",
     "websocket-stream": "1.4.0",
-    "dnode": "1.2.1"
+    "dnode": "1.2.2"
   },
   "devDependencies": {
     "should": "4.0.4",


### PR DESCRIPTION
dnode 1.2.1 doesn't compile in Node v4

Sorry to keep spamming you with these, I'm finding them as I'm trying to rebuild my local project. :)