### PR TITLE
Allow intermediate reply

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -1,6 +1,7 @@
 var events = require("events");
 var util = require("util");
 var crypto = require("crypto");
+var stream = require("stream");
 var Queue = require("./queue");
 
 function _noop() {}
@@ -429,6 +430,21 @@ Service.prototype._handleRequest = function(request, id) {
           _done();
         }
       };
+
+      // Create a write stream to stream data back to the requester
+      _reply.createWriteStream = function() {
+        return new stream.Writable({
+          write: function(chunk, encoding, cb) {
+            requester.q.push({ err: null, reply: chunk, reqId: request.reqId, intermediateReply: true });
+            cb();
+          },
+          final: function(cb) {
+            requester.q.push({ err: null, reply: null, reqId: request.reqId });
+            cb();
+          }
+        });
+      };
+
       _reply.replyTo = request.replyTo;
     } else {
       // we don't need to send a reply

--- a/lib/service.js
+++ b/lib/service.js
@@ -313,11 +313,11 @@ Service.prototype.request = function(message, options, cb) {
   }
 
   options = options || {};
+  options.reqTimeout = options.reqTimeout || this.options.reqTimeout;
 
   var _this = this;
   var reqId = Date.now() + "" + Math.random();
   var replyTo = undefined;
-  var reqTimeout = options.reqTimeout || this.options.reqTimeout;
   if (cb) {
     ++this.inflight;
     replyTo = this.replyTo;
@@ -328,10 +328,11 @@ Service.prototype.request = function(message, options, cb) {
           reqId: reqId,
           err: "timeout"
         });
-      }, reqTimeout)
+      }, options.reqTimeout),
+      options: options
     };
   }
-  return this.qService.push({ data: message, replyTo: replyTo, reqId: reqId, expires: Date.now() + reqTimeout });
+  return this.qService.push({ data: message, replyTo: replyTo, reqId: reqId, expires: Date.now() + options.reqTimeout });
 };
 
 /**
@@ -409,7 +410,7 @@ Service.prototype._handleRequest = function(request, id) {
       this._touchRequester(request.replyTo);
 
       // sends the reply back to the requester
-      _reply = function(err, reply) {
+      _reply = function(err, reply, intermediateReply) {
         if (err instanceof Error) {
           err = Object.keys(err).reduce(
             function(res, prop) {
@@ -422,9 +423,11 @@ Service.prototype._handleRequest = function(request, id) {
             }
           );
         }
-        requester.q.push({ err: err, reply: reply, reqId: request.reqId });
-        requester = undefined;
-        _done();
+        requester.q.push({ err: err, reply: reply, reqId: request.reqId, intermediateReply: intermediateReply });
+        if (!intermediateReply) {
+          requester = undefined;
+          _done();
+        }
       };
       _reply.replyTo = request.replyTo;
     } else {
@@ -455,13 +458,26 @@ Service.prototype._handleReply = function(reply, id) {
     if (!data) {
       return;
     }
-    delete this.pendingReplies[reply.reqId];
+
     // disable the timeout
     clearTimeout(data.timeout);
+
+    if (!data.options.allowIntermediateReply || !reply.intermediateReply) {
+      delete this.pendingReplies[reply.reqId];
+      --this.inflight;
+      this._shutdown(); // if we have not been asked to disconnect, this will do nothing
+    } else {
+      var _this = this;
+      // reset the timeout
+      data.timeout = setTimeout(function() {
+        _this._handleReply({
+          reqId: reply.reqId,
+          err: "timeout"
+        });
+      }, data.options.reqTimeout);
+    }
     // invoke the callback
-    data.cb.call(null, reply.err, reply.reply);
-    --this.inflight;
-    this._shutdown(); // if we have not been asked to disconnect, this will do nothing
+    data.cb.call(null, reply.err, reply.reply, reply.intermediateReply || false);
   } catch (e) {
     this.logger.warning("failed to handle incoming reply: " + e.message);
   }

--- a/test/test1.direct.noderedis.mocha.js
+++ b/test/test1.direct.noderedis.mocha.js
@@ -217,6 +217,11 @@ describe('BusMQ direct connectivity using node-redis', function() {
       tf.serviceServesRequesterPushes(bus,done);
     });
 
+    it('should receive a request and return multiple replies', function(done) {
+      var bus = Bus.create({redis: redisUrls, logger: console});
+      tf.serviceServesRequesterPushesIntermediateReply(bus,done);
+    });
+
     it('should handle a request without returning a reply', function(done) {
       var bus = Bus.create({redis: redisUrls, logger: console});
       tf.serviceServesRequesterPushesNoReply(bus,done);

--- a/test/test2.direct.ioredis.mocha.js
+++ b/test/test2.direct.ioredis.mocha.js
@@ -220,6 +220,11 @@ describe('BusMQ direct connectivity using ioredis', function() {
       tf.serviceServesRequesterPushes(bus,done);
     });
 
+    it('should receive a request and return multiple replies', function(done) {
+      var bus = Bus.create({driver: 'ioredis', redis: redisUrls, logger: console});
+      tf.serviceServesRequesterPushesIntermediateReply(bus,done);
+    });
+
     it('should handle a request without returning a reply', function(done) {
       var bus = Bus.create({driver: 'ioredis', redis: redisUrls, logger: console});
       tf.serviceServesRequesterPushesNoReply(bus,done);

--- a/test/test3.sentinels.mocha.js
+++ b/test/test3.sentinels.mocha.js
@@ -223,6 +223,11 @@ describe('BusMQ sentinels', function() {
       tf.serviceServesRequesterPushes(bus,done);
     });
 
+    it('should receive a request and return multiple replies', function(done) {
+      var bus = Bus.create({driver: 'ioredis', layout: 'sentinels', redis: redisUrls, logger: console});
+      tf.serviceServesRequesterPushesIntermediateReply(bus,done);
+    });
+
     it('should handle a request without returning a reply', function(done) {
       var bus = Bus.create({driver: 'ioredis', layout: 'sentinels', redis: redisUrls, logger: console});
       tf.serviceServesRequesterPushesNoReply(bus,done);

--- a/test/test4.cluster.mocha.js
+++ b/test/test4.cluster.mocha.js
@@ -221,6 +221,11 @@ describe('BusMQ Cluster', function() {
       tf.serviceServesRequesterPushes(bus,done);
     });
 
+    it('should receive a request and return multiple replies', function(done) {
+      var bus = Bus.create({driver: 'ioredis', layout: 'cluster', redis: redisUrls, logger: console});
+      tf.serviceServesRequesterPushesIntermediateReply(bus,done);
+    });
+
     it('should handle a request without returning a reply', function(done) {
       var bus = Bus.create({driver: 'ioredis', layout: 'cluster', redis: redisUrls, logger: console});
       tf.serviceServesRequesterPushesNoReply(bus,done);


### PR DESCRIPTION
Hi,

I've added functionality to the service to allow for intermediate replies to a request.
This can be used to indicate if the service is actually fulfilling the request or make a sort of streaming reply possible. 

In our case we want to replace the inter service HTTP communication with a message bus to simplify configuration and deployment. We have a few HTTP endpoints that stream data and using intermediate replies on the bus we can keep this behavior.